### PR TITLE
Fix the link to Release Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ If facing any issues, look for **Troubleshooting** section in the respective doc
 
 ## Release Notes
 
-[Release notes](./Documentation/RELEASE_NOTES.md) for the SDK.
+[Release notes](./documentation/RELEASE_NOTES.md) for the SDK.


### PR DESCRIPTION
It should be documentation instead of Documentation