### PR TITLE
Fix: Ensure trackPushToken resolves promise on success in iOS

### DIFF
--- a/ios/Exponea+Tracking.swift
+++ b/ios/Exponea+Tracking.swift
@@ -112,6 +112,7 @@ extension Exponea {
             return
         }
         Exponea.exponeaInstance.trackPushToken(token)
+        resolve(nil)
     }
 
     @objc(trackHmsPushToken:resolve:reject:)


### PR DESCRIPTION
### Description:

This PR addresses an issue in the iOS implementation of the `trackPushToken` method where the promise was not being resolved, causing the app to get stuck.
The resolve block is now called after the `trackPushToken` method, ensuring the promise is resolved successfully.
This change aligns the iOS implementation with the existing Android implementation, maintaining consistency across platforms.

### Changes:
- Added a call to `resolve(nil)` after `Exponea.exponeaInstance.trackPushToken(token)` to ensure the promise is resolved.

### Reason for Change:
https://github.com/exponea/exponea-react-native-sdk/blob/a9a5c7607e76563fa72b22c033ab2245eb63e1ba/ios/Exponea%2BTracking.swift#L105-L115

Previously, the `trackPushToken` method did not call the resolve block, which caused the promise to remain unresolved and the application to hang. By resolving the promise, we ensure that the method completes successfully, allowing the app to continue execution as expected. 
This also ensures consistency with the Android implementation, which already resolves the promise after tracking the token.

### Consistency with Android:
The Android implementation of trackPushToken already resolves the promise after tracking the push token:
https://github.com/exponea/exponea-react-native-sdk/blob/a9a5c7607e76563fa72b22c033ab2245eb63e1ba/android/src/main/java/com/exponea/ExponeaModule.kt#L634-L640

By making this change to the iOS implementation, both platforms handle the promise resolution in a consistent manner, improving reliability and maintainability.

### Testing:

- Verified that the `trackPushToken` method now resolves the promise successfully on iOS.