### PR TITLE
Allow WebViewCookies option to be passed through

### DIFF
--- a/android/src/main/java/com/exponea/ConfigurationParser.kt
+++ b/android/src/main/java/com/exponea/ConfigurationParser.kt
@@ -240,6 +240,8 @@ internal class ConfigurationParser(private val readableMap: ReadableMap) {
                         )
                     }
                 }
+                "allowWebViewCookies" ->
+                    configuration.allowWebViewCookies = map.getSafely("allowWebViewCookies", Boolean::class)
             }
         }
     }

--- a/android/src/test/java/com/exponea/ConfigurationParserTest.kt
+++ b/android/src/test/java/com/exponea/ConfigurationParserTest.kt
@@ -70,7 +70,8 @@ internal class ConfigurationParserTest {
                 pushChannelId = "mock-push-channel-id",
                 pushNotificationImportance = NotificationManager.IMPORTANCE_HIGH,
                 httpLoggingLevel = ExponeaConfiguration.HttpLoggingLevel.BODY,
-                allowDefaultCustomerProperties = false
+                allowDefaultCustomerProperties = false,
+                allowWebViewCookies = true
             ),
             ConfigurationParser(data as ReadableMap).parse()
         )
@@ -179,4 +180,15 @@ internal class ConfigurationParserTest {
         val config = ConfigurationParser(data as ReadableMap).parse()
         assertEquals(false, config.requirePushAuthorization)
     }
+
+    @Test
+    fun `allowWebViewCookies should default to false when not set`() {
+        val data = JavaOnlyMap.of(
+            "projectToken", "mock-project-token",
+            "authorizationToken", "mock-authorization-token"
+        )
+        val config = ConfigurationParser(data as ReadableMap).parse()
+        assertEquals(false, config.allowWebViewCookies)
+    }
+
 }

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -69,6 +69,8 @@ export interface AndroidConfiguration {
   pushNotificationImportance?: PushNotificationImportance;
   /** Level of HTTP logging */
   httpLoggingLevel?: HttpLoggingLevel;
+  /** If true, allows the Exponea SDK WebViews to accept and store cookies without clearing global app cookies */
+  allowWebViewCookies?: boolean;
 }
 
 export interface IOSConfiguration {

--- a/src/__tests__/Configuration.test.ts
+++ b/src/__tests__/Configuration.test.ts
@@ -56,6 +56,7 @@ test('should construct full configuration', () => {
       pushNotificationImportance: PushNotificationImportance.HIGH,
       httpLoggingLevel: HttpLoggingLevel.BODY,
       requirePushAuthorization: false,
+      allowWebViewCookies: true,
     },
     ios: {
       requirePushAuthorization: false,

--- a/src/test_data/configurationComplete.json
+++ b/src/test_data/configurationComplete.json
@@ -14,7 +14,10 @@
     "string": "value",
     "boolean": false,
     "number": 3.14159,
-    "array": ["value1", "value2"],
+    "array": [
+      "value1",
+      "value2"
+    ],
     "object": {
       "key": "value"
     }
@@ -33,7 +36,8 @@
     "pushChannelId": "mock-push-channel-id",
     "pushNotificationImportance": "HIGH",
     "httpLoggingLevel": "BODY",
-    "requirePushAuthorization": false
+    "requirePushAuthorization": false,
+    "allowWebViewCookies": true
   },
   "ios": {
     "requirePushAuthorization": false,


### PR DESCRIPTION
The React Native SDK does not currently allow for the `allowWebViewCookies` option to be passed through to the Android SDK, which means it will always default to `false`, thereby disabling cookies at a global level across the entire app.

We have a usecase where we need this setting to be set to `true`, but we can't call `Exponea.configure` at the Android SDK level.

This change allows this option to be passed through via the JS SDK.

We woudl be grateful if this change could be back-ported to 2.6 and 2.7 versions of the SDK as well, to allow us to use this option without migrating to the latest major version.