### PR TITLE
fix: Static library compilation in podspec

### DIFF
--- a/react-native-exponea-sdk.podspec
+++ b/react-native-exponea-sdk.podspec
@@ -33,16 +33,18 @@ Pod::Spec.new do |s|
   # uses) so wholemodule optimization is preserved for dynamic/default builds.
   # See: https://github.com/exponea/exponea-react-native-sdk/issues/138
   if ENV['USE_FRAMEWORKS'] == 'static'
-    s.pod_target_xcconfig ||= {}
-    s.pod_target_xcconfig['SWIFT_COMPILATION_MODE'] = 'incremental'
-    s.pod_target_xcconfig['SWIFT_OBJC_INTERFACE_HEADER_NAME'] = 'react_native_exponea_sdk-Swift.h'
-    s.pod_target_xcconfig['HEADER_SEARCH_PATHS'] = [
-      s.pod_target_xcconfig['HEADER_SEARCH_PATHS'],
+    pod_target_xcconfig = s.attributes_hash['pod_target_xcconfig'] || {}
+    pod_target_xcconfig['HEADER_SEARCH_PATHS'] = [
+      pod_target_xcconfig['HEADER_SEARCH_PATHS'] || '$(inherited)',
       '"$(PODS_ROOT)/../../node_modules/react-native/ReactCommon"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-exponea-sdk/react_native_exponea_sdk.framework/Headers"',
       '"$(OBJECT_FILE_DIR_normal)/$(CURRENT_ARCH)"',
       '"$(DERIVED_SOURCES_DIR)"'
     ].compact.join(' ')
+    s.pod_target_xcconfig = pod_target_xcconfig.merge(
+      'SWIFT_COMPILATION_MODE' => 'incremental',
+      'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'react_native_exponea_sdk-Swift.h'
+    )
   end
 end

--- a/react-native-exponea-sdk.podspec
+++ b/react-native-exponea-sdk.podspec
@@ -33,8 +33,16 @@ Pod::Spec.new do |s|
   # uses) so wholemodule optimization is preserved for dynamic/default builds.
   # See: https://github.com/exponea/exponea-react-native-sdk/issues/138
   if ENV['USE_FRAMEWORKS'] == 'static'
+    s.pod_target_xcconfig ||= {}
     s.pod_target_xcconfig['SWIFT_COMPILATION_MODE'] = 'incremental'
     s.pod_target_xcconfig['SWIFT_OBJC_INTERFACE_HEADER_NAME'] = 'react_native_exponea_sdk-Swift.h'
-    s.pod_target_xcconfig['HEADER_SEARCH_PATHS'] = '$(inherited) "$(PODS_ROOT)/../../node_modules/react-native/ReactCommon" "${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/react-native-exponea-sdk/react_native_exponea_sdk.framework/Headers" "$(OBJECT_FILE_DIR_normal)/$(CURRENT_ARCH)" "$(DERIVED_SOURCES_DIR)"'
+    s.pod_target_xcconfig['HEADER_SEARCH_PATHS'] = [
+      s.pod_target_xcconfig['HEADER_SEARCH_PATHS'],
+      '"$(PODS_ROOT)/../../node_modules/react-native/ReactCommon"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/react-native-exponea-sdk/react_native_exponea_sdk.framework/Headers"',
+      '"$(OBJECT_FILE_DIR_normal)/$(CURRENT_ARCH)"',
+      '"$(DERIVED_SOURCES_DIR)"'
+    ].compact.join(' ')
   end
 end

--- a/react-native-exponea-sdk.podspec
+++ b/react-native-exponea-sdk.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
       '"$(DERIVED_SOURCES_DIR)"'
     ].compact.join(' ')
     s.pod_target_xcconfig = pod_target_xcconfig.merge(
+      'CLANG_CXX_LANGUAGE_STANDARD' => rct_cxx_language_standard(),
       'SWIFT_COMPILATION_MODE' => 'incremental',
       'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'react_native_exponea_sdk-Swift.h'
     )

--- a/react-native-exponea-sdk.podspec
+++ b/react-native-exponea-sdk.podspec
@@ -34,5 +34,7 @@ Pod::Spec.new do |s|
   # See: https://github.com/exponea/exponea-react-native-sdk/issues/138
   if ENV['USE_FRAMEWORKS'] == 'static'
     s.pod_target_xcconfig['SWIFT_COMPILATION_MODE'] = 'incremental'
+    s.pod_target_xcconfig['SWIFT_OBJC_INTERFACE_HEADER_NAME'] = 'react_native_exponea_sdk-Swift.h'
+    s.pod_target_xcconfig['HEADER_SEARCH_PATHS'] = '$(inherited) "$(PODS_ROOT)/../../node_modules/react-native/ReactCommon" "${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers" "${PODS_CONFIGURATION_BUILD_DIR}/react-native-exponea-sdk/react_native_exponea_sdk.framework/Headers" "$(OBJECT_FILE_DIR_normal)/$(CURRENT_ARCH)" "$(DERIVED_SOURCES_DIR)"'
   end
 end


### PR DESCRIPTION
## Summary

- Updates the podspec configuration used when `USE_FRAMEWORKS=static`.
- Explicitly preserves React Native's clang C++ language standard in the merged pod target config.
- Explicitly sets the generated Swift Objective-C header name.
- Appends the required React Native and generated Swift header search paths without replacing existing pod target config.

## Issues Resolved

Static framework iOS builds could fail because Objective-C sources attempted to import `react_native_exponea_sdk-Swift.h` before Xcode exposed it reliably.

The previous direct `pod_target_xcconfig[...]` approach could also fail during `pod install` because CocoaPods exposes `pod_target_xcconfig=` as a writer, but not as a readable hash accessor.

When overriding pod target config for static framework builds, the podspec must continue to carry React Native's configured clang C++ language standard so the target stays aligned with the React Native build settings.

## How

- Reads any existing `pod_target_xcconfig` from `s.attributes_hash`.
- Preserves existing config values and existing `HEADER_SEARCH_PATHS`.
- Falls back to `$(inherited)` when no header search paths are already present.
- Assigns the merged config back via `s.pod_target_xcconfig = ...`.
- Sets `CLANG_CXX_LANGUAGE_STANDARD` to `rct_cxx_language_standard()`.
- Keeps `SWIFT_COMPILATION_MODE` set to `incremental` for static framework builds.
- Sets `SWIFT_OBJC_INTERFACE_HEADER_NAME` to `react_native_exponea_sdk-Swift.h`.

## Validation

- `git diff --check`
- `ruby -c react-native-exponea-sdk.podspec`
