### PR TITLE
fix: Improve thread safety

### DIFF
--- a/ios/CarouselInAppContentBlockViewProxy.swift
+++ b/ios/CarouselInAppContentBlockViewProxy.swift
@@ -248,14 +248,19 @@ public class CarouselInAppContentBlockViewProxy: UIView, DefaultContentBlockCaro
     }
 
     private func notifyDimensChanged(width: CGFloat, height: CGFloat) {
-        eventEmitter?.emitDimensChanged(
-            width: Double(width),
-            height: Double(height)
-        )
+        onMain { [weak self] in
+            self?.eventEmitter?.emitDimensChanged(
+                width: Double(width),
+                height: Double(height)
+            )
+        }
     }
 
     private func notifyContentBlockCarouselEvent(_ event: ContentBlockCarouselEvent) {
-        eventEmitter?.emitContentBlockEvent(data: event.toDictionary() as NSDictionary)
+        let data = event.toDictionary() as NSDictionary
+        onMain { [weak self] in
+            self?.eventEmitter?.emitContentBlockEvent(data: data)
+        }
     }
 
     private func notifyContentFilterRequest(input: [ExponeaSDK.InAppContentBlockResponse]) {
@@ -274,7 +279,10 @@ public class CarouselInAppContentBlockViewProxy: UIView, DefaultContentBlockCaro
             return
         }
 
-        eventEmitter?.emitDataRequest(data: ["requestType": "filter", "data": jsonString] as NSDictionary)
+        let payload: NSDictionary = ["requestType": "filter", "data": jsonString]
+        onMain { [weak self] in
+            self?.eventEmitter?.emitDataRequest(data: payload)
+        }
     }
 
     private func notifyContentSortRequest(input: [ExponeaSDK.InAppContentBlockResponse]) {
@@ -293,6 +301,9 @@ public class CarouselInAppContentBlockViewProxy: UIView, DefaultContentBlockCaro
             return
         }
 
-        eventEmitter?.emitDataRequest(data: ["requestType": "sort", "data": jsonString] as NSDictionary)
+        let payload: NSDictionary = ["requestType": "sort", "data": jsonString]
+        onMain { [weak self] in
+            self?.eventEmitter?.emitDataRequest(data: payload)
+        }
     }
 }

--- a/ios/DictionaryExtensions.swift
+++ b/ios/DictionaryExtensions.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+func onMain(_ block: @escaping () -> Void) {
+    if Thread.isMainThread {
+        block()
+    } else {
+        DispatchQueue.main.async(execute: block)
+    }
+}
+
 /// Error types for Exponea configuration
 public enum ExponeaDataError: Error {
     case invalidType(for: String)

--- a/ios/ExponeaBridge.swift
+++ b/ios/ExponeaBridge.swift
@@ -1080,8 +1080,9 @@ public class ExponeaRNVersion: NSObject, ExponeaVersionProvider {
     }
 
     private func sendEventToJS(name: String, body: Any?) {
-        // Use RCTEventEmitter to send events to JavaScript
-        eventEmitter?.sendEvent(withName: name, body: body)
+        onMain { [weak self] in
+            self?.eventEmitter?.sendEvent(withName: name, body: body)
+        }
     }
 
     private func convertToJSONString(_ dict: [AnyHashable: Any]) throws -> String {

--- a/ios/InAppContentBlocksPlaceholder.swift
+++ b/ios/InAppContentBlocksPlaceholder.swift
@@ -92,10 +92,12 @@ public class InAppContentBlocksPlaceholder: UIView, InAppContentBlockCallbackTyp
     }
 
     private func notifyDimensChanged(width: CGFloat, height: CGFloat) {
-        eventEmitter?.emitDimensChanged(
-            width: Double(width),
-            height: Double(height)
-        )
+        onMain { [weak self] in
+            self?.eventEmitter?.emitDimensChanged(
+                width: Double(width),
+                height: Double(height)
+            )
+        }
     }
 
     private func notifyInAppContentBlockEvent(
@@ -137,7 +139,10 @@ public class InAppContentBlocksPlaceholder: UIView, InAppContentBlockCallbackTyp
             data["errorMessage"] = errorMessage
         }
 
-        eventEmitter?.emitContentBlockEvent(data: data as NSDictionary)
+        let eventData = data as NSDictionary
+        onMain { [weak self] in
+            self?.eventEmitter?.emitContentBlockEvent(data: eventData)
+        }
     }
 
     public func onMessageShown(placeholderId: String, contentBlock: ExponeaSDK.InAppContentBlockResponse) {


### PR DESCRIPTION
## Summary

  - Adds an `onMain` helper to dispatch work to the main thread, executing synchronously if already on the main thread
  and asynchronously otherwise.
  - Updates `sendEventToJS` in `ExponeaBridge` to dispatch through `onMain`, ensuring all in-app message delegate
  callbacks and segmentation callbacks reach the React Native bridge on the main thread.
  - Updates `notifyDimensChanged`, `notifyContentBlockCarouselEvent`, `notifyContentFilterRequest`, and
  `notifyContentSortRequest` in `CarouselInAppContentBlockViewProxy` to dispatch through `onMain`.
  - Updates `notifyDimensChanged` and `notifyInAppContentBlockEvent` in `InAppContentBlocksPlaceholder` to dispatch
  through `onMain`.

  ## Issues Resolved

  SDK delegate callbacks for in-app messages, content blocks, and segmentation arrive on background threads. Calling
  `RCTEventEmitter.sendEvent` and UIKit layout APIs (dimension change notifications) from a background thread causes
  undefined behaviour under the New Architecture / Fabric renderer and can result in crashes or dropped events.

  ## How

  - **`DictionaryExtensions.swift`:** Adds `onMain(_:)` — a free function matching the pattern used in the upstream
  `exponea-ios-sdk`. When the caller is already on the main thread it executes the block inline; otherwise it schedules
  it with `DispatchQueue.main.async`. This avoids unnecessary re-queuing for callbacks that already arrive on main.
  - **`ExponeaBridge.swift`:** `sendEventToJS` wraps its `eventEmitter?.sendEvent` call in `onMain`, covering all event
  emission paths: `inAppMessageShown`, `inAppMessageError`, `inAppMessageClickAction`, `inAppMessageCloseAction`, and
  `emitNewSegments`.
  - **`CarouselInAppContentBlockViewProxy.swift` / `InAppContentBlocksPlaceholder.swift`:** Each `notify*` method
  serialises any SDK reference types to value-safe representations (e.g. `NSDictionary`) on the calling thread before
  the `onMain` hop, so no SDK objects cross a thread boundary.